### PR TITLE
Fix byte literals in MPU6050 scripts

### DIFF
--- a/analog_sensor_2/mpu6050.py
+++ b/analog_sensor_2/mpu6050.py
@@ -25,13 +25,13 @@ def reset_mpu6050():
 
 # MPU-6050の初期化
 def init_mpu6050():
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x6B, b'0x00')  # スリープ解除
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x6C, b'0x00')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x1B, b'0x00')  # ジャイロ範囲±250°/s
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x1C, b'0x00')  # 加速度範囲±2g
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x19, b'0x04')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x37, b'0x02')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x38, b'0x01')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x6B, b'\x00')  # スリープ解除
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x6C, b'\x00')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x1B, b'\x00')  # ジャイロ範囲±250°/s
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x1C, b'\x00')  # 加速度範囲±2g
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x19, b'\x04')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x37, b'\x02')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, 0x38, b'\x01')
 
 reset_mpu6050()
 init_mpu6050()

--- a/analog_sensor_2/mpu6050_init.py
+++ b/analog_sensor_2/mpu6050_init.py
@@ -27,11 +27,11 @@ USER_CTRL = 0x6A
 
 # MPU-6050を初期化する関数
 def init_mpu6050():
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, PWR_MGMT_1, b'0x01')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, PWR_MGMT_2, b'0x00')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, SIGNAL_PATH_RESET, b'0x00')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, USER_CTRL, b'0x00')
-    i2c.writeto_mem(MPU6050_I2C_ADDRESS, SMPLRT_DIV, b'0x04')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, PWR_MGMT_1, b'\x01')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, PWR_MGMT_2, b'\x00')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, SIGNAL_PATH_RESET, b'\x00')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, USER_CTRL, b'\x00')
+    i2c.writeto_mem(MPU6050_I2C_ADDRESS, SMPLRT_DIV, b'\x04')
 
 init_mpu6050()
 pwr_mgmt_2 = i2c.readfrom_mem(MPU6050_I2C_ADDRESS, PWR_MGMT_2, 1)


### PR DESCRIPTION
## Summary
- correct byte literal usage in `mpu6050_init.py`
- correct byte literal usage in `mpu6050.py`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686debe58528832a9ec6ab18bc1d5db3