### PR TITLE
Fix callback names

### DIFF
--- a/event_hundler/practice07-03.py
+++ b/event_hundler/practice07-03.py
@@ -21,12 +21,12 @@ def set_event(led_pin_no=2, button_pin_no=0):
     global led
     led = Pin(led_pin_no, Pin.OUT)
     button = Pin(button_pin_no, Pin.IN)
-    button.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING, handler=button_triggerd) 
+    button.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING, handler=button_triggered) 
 
     return
 
 
-def button_triggerd(pin):
+def button_triggered(pin):
     """
     BUTTONからイベントが発生際の処理、
     押されていればLEDを点灯、離されていれば消灯する。

--- a/first_iot_device/practice09-00.py
+++ b/first_iot_device/practice09-00.py
@@ -16,7 +16,7 @@ led_sensor_detect = Pin(PIN_NO_SENSOR_LED, Pin.OUT)  # センサ反応中に点�
 sensor = Pin(PIN_NO_IR_SENSOR, Pin.IN)  # 人感センサ
 
 
-def sensor_triggerd(sensor_pin):
+def sensor_triggered(sensor_pin):
     """
     センサが押されたら
 
@@ -94,7 +94,7 @@ def post_data(url, data):
 # Wi-Fiに接続
 wlan = connect_wifi(SSID, PASSWORD)
 
-sensor.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING, handler=sensor_triggerd) 
+sensor.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING, handler=sensor_triggered) 
 
 while True:
     time.sleep(1)

--- a/first_iot_device/practice09-03.py
+++ b/first_iot_device/practice09-03.py
@@ -28,7 +28,7 @@ sensor_status = 0  # 前回割り込み時のセンサの状態
 count = 0   # センサの反応回数
 
 
-def sensor_triggerd(sensor_pin):
+def sensor_triggered(sensor_pin):
     """
     センサが押されたら
 
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     wlan = connect_wifi(SSID, PASSWORD)
     
     # センサへのトリガ設定
-    sensor.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING, handler=sensor_triggerd) 
+    sensor.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING, handler=sensor_triggered) 
     # ボタンへのトリガ設定
     button.irq(trigger=Pin.IRQ_FALLING, handler=button_push)
 


### PR DESCRIPTION
## Summary
- correct spelling of callback names `sensor_triggered` and `button_triggered`

## Testing
- `grep -R "sensor_triggerd" -n | wc -l`
- `grep -R "button_triggerd" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_686debea786c832a826147e4b5582164