### PR TITLE
docs: correct SPI description

### DIFF
--- a/esp32_doc/ReadMe.md
+++ b/esp32_doc/ReadMe.md
@@ -80,6 +80,5 @@ GPIOを入力の場合にはON/OFFの読み出しを、出力の場合にはON/O
   - クロック信号　(SCLK,CLK,SCK[Serial Clock]) SPICLK
   - スレーブ選択　(CS[Chip Select]/SS[Slave Select]/SYNC/ENABLE) SPICS0
   - 書き込み保護ライン(HSPI_WP / VSPI_WP)デバイスで書き込み保護機能を制御するために使用
-  - 保持データライン（HSPI_HD / VSPI_HD）　デバイスを一時的に停止させるために使用さ
-
+  - 保持データライン（HSPI_HD / VSPI_HD） デバイスを一時的に停止させるために使用される
 [トップへ戻る](../README.md)


### PR DESCRIPTION
## Summary
- fix truncated bullet in esp32 documentation

## Testing
- `git show -U3 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e218a0ac8832a99eb376ae8ab3328